### PR TITLE
LibWeb: Cache contained elements in measure_scrollable_overflow()

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -72,7 +72,7 @@ LayoutState::UsedValues const& LayoutState::get(NodeWithStyle const& node) const
 }
 
 // https://www.w3.org/TR/css-overflow-3/#scrollable-overflow
-static CSSPixelRect measure_scrollable_overflow(Box const& box)
+static CSSPixelRect measure_scrollable_overflow(Box const& box, HashMap<Box const*, Vector<Box const*>> containing_blocks_map = {})
 {
     if (!box.paintable_box())
         return {};
@@ -100,18 +100,38 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
     //   and whose border boxes are positioned not wholly in the negative scrollable overflow region,
     //   FIXME: accounting for transforms by projecting each box onto the plane of the element that establishes its 3D rendering context. [CSS3-TRANSFORMS]
     if (!box.children_are_inline()) {
-        box.for_each_in_subtree_of_type<Box>([&box, &scrollable_overflow_rect, &content_overflow_rect](Box const& child) {
-            if (!child.paintable_box())
-                return TraversalDecision::Continue;
+        if (containing_blocks_map.is_empty()) {
+            NodeWithStyle const* ancestor = &box;
+            while (ancestor->parent()) {
+                ancestor = ancestor->parent();
+            }
+            Box const* root_box = static_cast<Box const*>(ancestor);
+            root_box->for_each_in_inclusive_subtree_of_type<Box>([&containing_blocks_map](auto& child) {
+                if (!child.paintable_box())
+                    return TraversalDecision::Continue;
 
-            if (child.containing_block() != &box)
+                // Make sure to add each node to the cache, even if it does not have any contained elements
+                if (!containing_blocks_map.contains(&child)) {
+                    containing_blocks_map.set(&child, {});
+                }
+
+                auto* containing_block = child.containing_block();
+                if (!containing_blocks_map.contains(containing_block)) {
+                    containing_blocks_map.set(containing_block, {});
+                }
+                containing_blocks_map.get(containing_block)->append(&child);
                 return TraversalDecision::Continue;
+            });
+        }
+
+        for (auto& childp : *containing_blocks_map.get(&box)) {
+            auto& child = *childp;
 
             auto child_border_box = child.paintable_box()->absolute_border_box_rect();
 
             // NOTE: Here we check that the child is not wholly in the negative scrollable overflow region.
             if (child_border_box.bottom() < 0 || child_border_box.right() < 0)
-                return TraversalDecision::Continue;
+                continue;
 
             scrollable_overflow_rect = scrollable_overflow_rect.united(child_border_box);
             content_overflow_rect = content_overflow_rect.united(child_border_box);
@@ -121,15 +141,13 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
             //   provided they themselves have overflow: visible (i.e. do not themselves trap the overflow)
             //   and that scrollable overflow is not already clipped (e.g. by the clip property or the contain property).
             if (is<Viewport>(box) || child.computed_values().overflow_x() == CSS::Overflow::Visible || child.computed_values().overflow_y() == CSS::Overflow::Visible) {
-                auto child_scrollable_overflow = measure_scrollable_overflow(child);
+                auto child_scrollable_overflow = measure_scrollable_overflow(child, containing_blocks_map);
                 if (is<Viewport>(box) || child.computed_values().overflow_x() == CSS::Overflow::Visible)
                     scrollable_overflow_rect.unite_horizontally(child_scrollable_overflow);
                 if (is<Viewport>(box) || child.computed_values().overflow_y() == CSS::Overflow::Visible)
                     scrollable_overflow_rect.unite_vertically(child_scrollable_overflow);
             }
-
-            return TraversalDecision::Continue;
-        });
+        }
     }
 
     // FIXME: - The margin areas of grid item and flex item boxes for which the box establishes a containing block.


### PR DESCRIPTION
https://github.com/LadybirdBrowser/ladybird/pull/1268 introduced a performance regression by making it so when computing scrollable overflow for a layout box, we visit each node in the box's subtree and ask if its containing block is the box. Since `measure_scrollable_overflow` is recursive, we wind up making passes through overlapping subtrees, which has the effect of asking the same nodes repeatedly who its containing block is.

Instead of asking the same node repeatedly who its containing block is, we first do a single scan of the root subtree and cache all containing blocks. Then we feed this cache to `compute_scrollable_overflow` for boxes to use.